### PR TITLE
site.conf: Remove 11s AU branch from config

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -226,31 +226,7 @@
                     'cb0141d79e131854eb05d6c9ce5cc237baa462e288b7fcb0eadbd92da8f34b3f', -- Buildbot Dois, AutoDeploy
                 },
             },
-            
-            -- 802.11s builds are rolled out automatically whenever a commit is pushed into the exp802.11s branch
-            exp11s = {
-                name = '802.11s',
-                mirrors = {
-                    'http://[fda1:384a:74de:4242::fd00]/firmware/802.11s/sysupgrade/',
-                    'http://[fda1:384a:74de:4242::fd01]/firmware/802.11s/sysupgrade/',
-                    'http://[fda1:384a:74de:4242::fd02]/firmware/802.11s/sysupgrade/',
-                    'http://[fda1:384a:74de:4242::fd03]/firmware/802.11s/sysupgrade/',
-                    'http://0.updates.services.ffki/firmware/802.11s/sysupgrade/',
-                    'http://1.updates.services.ffki/firmware/802.11s/sysupgrade/',
-                    },
-                good_signatures = 1,
-                pubkeys = {
-                    'bbb814470889439c04667748c30aabf25fb800621e67544bee803fd1b342ace3', -- sargon
-                    '8d16e1b88bcac28b493d6eadbce97bd223a65b3282a533c1f15f4b616b0d732a', -- BenBE
-                    'b952fb086ae4987a1807af0ed14683117af663f6c075950d832b761a6963be9d', -- Tarnatos
-                    '9885f836464abf3633f92701e4febeefec54f481d8b6cd39085e6ad24162ff82', -- rubo77
-                    '359ec3619184f1bdfe26515cf5ba2b016ba23489db2a371cbf5c3cee9d061110', -- Sven (FL)
-                    '622e6eccd148c4d4a53ee367dd1d73740da6795fe8dc2df1ff022bf1b4344714', -- eNBeWe
-                    '1c24d4b41680f16cda0c19ad53de84ef1be3a86870e6fec6454833a6a46f7122', -- Buildbot Um, AutoDeploy
-                    'cb0141d79e131854eb05d6c9ce5cc237baa462e288b7fcb0eadbd92da8f34b3f', -- Buildbot Dois, AutoDeploy
-                },
-            },
-            
+
             -- release candidate for the next stable
             -- this contains only tested versions and is not rolled out automatically
             rc = {


### PR DESCRIPTION
The 11s config has been merged to the new nightly build. Therefore the stand-alone 11s AU path is deprecated.